### PR TITLE
add deployment example for ARM processor #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Formance Helm charts 
+# Formance Helm charts
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance-ledger)](https://artifacthub.io/packages/search?repo=formance-ledger)
 ## How to use Helm charts
@@ -13,12 +13,18 @@ Installing the ledger:
 helm install ledger formance/ledger
 ```
 
-**The Formance Helm chart did not provides any dependencies. For developement purpose only, you can install PostgreSQL database using this command:**
+## For developement purposes only!
+
+**The Formance Helm chart does not provide any dependencies. You can install the PostgreSQL database using this command:**
 ```
-helm repo add bitnami https://charts.bitnami.com/bitnami 
+helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install postgres bitnami/postgresql --set global.postgresql.auth.username=ledger --set global.postgresql.auth.password=ledger --set global.postgresql.auth.database=ledger
 ```
 
+**Due to bitnami's docker image only supporting AMD processors, a few helm values need to be updated to install PostgreSQL for ARM processors:**
+```
+helm install postgres bitnami/postgresql --set global.postgresql.auth.username=ledger --set global.postgresql.auth.password=ledger --set global.postgresql.auth.database=ledger --set image.repository=postgres --set image.tag=15-alpine --set nameOverride=postgres
+```
 
 ## Installation
 helm-docs can be installed using homebrew:
@@ -26,7 +32,7 @@ helm-docs can be installed using homebrew:
 brew install norwoodj/tap/helm-docs
 ```
 
-## Usage 
+## Usage
 ### Pre-commit hook
 If you want to automatically generate README.md files with a pre-commit hook, make sure you install the pre-commit binary, and add a .pre-commit-config.yaml file to your project. Then run:
 ```


### PR DESCRIPTION
# Fix issue  #26 
- Use official postgres image
- override hostname to avoid having to make changes to the formance chart

## Tests performed

```sh
k get pods
NAME                      READY   STATUS    RESTARTS   AGE
ledger-5bff5b8479-bmjkb   1/1     Running   0          58m
postgres-0                1/1     Running   0          58m

```

```sh
# connect
kubectl port-forward svc/ledger 8080:80

# LOGS
k logs ledger-5bff5b8479-bmjkb

time="2023-02-16T12:40:33Z" level=info msg=Request ip=10.244.1.1 latency="230.127µs" method=GET path=/_info status=200 user_agent=kube-probe/1.25
time="2023-02-16T12:40:33Z" level=info msg=Request ip=10.244.1.1 latency="268.585µs" method=GET path=/_info status=200 user_agent=kube-probe/1.25
time="2023-02-16T12:40:43Z" level=info msg=Request ip=10.244.1.1 latency="217.334µs" method=GET path=/_info status=200 user_agent=kube-probe/1.25
time="2023-02-16T12:40:43Z" level=info msg=Request ip=10.244.1.1 latency="300.46µs" method=GET path=/_info status=200 user_agent=kube-probe/1.25
time="2023-02-16T12:40:53Z" level=info msg=Request ip=10.244.1.1 latency="224.46µs" method=GET path=/_info status=200 user_agent=kube-probe/1.25
time="2023-02-16T12:40:53Z" level=info msg=Request ip=10.244.1.1 latency="376.46µs" method=GET path=/_info status=200 user_agent=kube-probe/1.25


```