### PR TITLE
fix: all templates/hpa.yaml metrics definition

### DIFF
--- a/charts/auth/templates/hpa.yaml
+++ b/charts/auth/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/control/templates/hpa.yaml
+++ b/charts/control/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -67,15 +67,11 @@ traefik:
       - type: Resource
         resource:
           name: memory
-          target:
-          type: Utilization
-          averageUtilization: 60
+          targetAverageUtilization: 60
       - type: Resource
         resource:
           name: cpu
-          target:
-          type: Utilization
-          averageUtilization: 60
+          targetAverageUtilization: 60
   resources:
     requests:
       cpu: "200m"

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -67,11 +67,15 @@ traefik:
       - type: Resource
         resource:
           name: memory
-          targetAverageUtilization: 60
+          target:
+          type: Utilization
+          averageUtilization: 60
       - type: Resource
         resource:
           name: cpu
-          targetAverageUtilization: 60
+          target:
+          type: Utilization
+          averageUtilization: 60
   resources:
     requests:
       cpu: "200m"

--- a/charts/ledger/templates/hpa.yaml
+++ b/charts/ledger/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/payments/templates/hpa.yaml
+++ b/charts/payments/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/search/templates/hpa.yaml
+++ b/charts/search/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/webhooks/templates/hpa.yaml
+++ b/charts/webhooks/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
*[k8s HPA docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#:~:text=maxReplicas%3A%2010-,metrics%3A,averageUtilization%3A%2050,-status%3A) were used as reference.

## complaining k8s manifest linter:
![image](https://user-images.githubusercontent.com/29926675/235308210-1aac729f-494e-4c9a-aff3-16a913eb6821.png)
![image](https://user-images.githubusercontent.com/29926675/235308387-eecbe93f-59cf-4bfa-8a8c-355aaf9782ea.png)

## what was done
replace:
```
targetAverageUtilization:
```
with
```
target:
          type: Utilization
          averageUtilization:
```
on any `hpa.yaml`

![image](https://user-images.githubusercontent.com/29926675/235307836-d108c895-955a-4acb-9ea1-7bfc137272e6.png)
PS: At first I replaced the contents in a values.yaml file (source of the invalid hpa.yaml wrong pattern?) but I reverted it with a fixup commit