### PR TITLE
chore: update chart and dependencies versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | [Demo](./charts/demo/README.md) | 2.0.0 |latest | Formance Private Regions Demo | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/demo)](https://artifacthub.io/packages/search?repo=demo) |
 | [Membership](./charts/membership/README.md) | v1.0.0-beta.17 |v0.35.3 | Formance Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | v1.0.0-beta.7 |764bb7e199e1d2882e4d5cd205eada0ef0abc283 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | v2.1.1 |latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | v2.1.2 |latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.5.3 |latest | Formance Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v2.1.0
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
-  version: v2.0.19
-digest: sha256:49f9c10fd891c344637f7f54a911e6b111b91cc4255ec6e95d3c74a1463b1df8
-generated: "2024-10-14T10:52:32.636937553Z"
+  version: v2.0.20
+digest: sha256:2a0778851fc3a82bfd0a519cdcc3b43c0fb2fc3360034bb05811738a198d458a
+generated: "2024-10-22T08:21:38.635778323Z"

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: "v2.1.1"
+version: "v2.1.2"
 appVersion: "latest"
 
 dependencies:
@@ -20,6 +20,6 @@ dependencies:
     repository: "file://../agent"
     condition: agent.enabled
   - name: operator
-    version: v2.0.19
+    version: v2.0.20
     repository: "oci://ghcr.io/formancehq/helm"
     condition: operator.enabled

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # regions
 
-![Version: v2.1.1](https://img.shields.io/badge/Version-v2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: v2.1.2](https://img.shields.io/badge/Version-v2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Private Regions Helm Chart
 
@@ -22,7 +22,7 @@ Formance Private Regions Helm Chart
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../agent | agent | v2.1.0 |
-| oci://ghcr.io/formancehq/helm | operator | v2.0.19 |
+| oci://ghcr.io/formancehq/helm | operator | v2.0.20 |
 
 ## Values
 
@@ -69,28 +69,28 @@ Formance Private Regions Helm Chart
 | versions.files."v1.0".stargate | string | `"v0.1.10"` |  |
 | versions.files."v1.0".wallets | string | `"v0.4.6"` |  |
 | versions.files."v1.0".webhooks | string | `"v2.0.18"` |  |
-| versions.files."v2.0".auth | string | `"v2.0.18"` |  |
-| versions.files."v2.0".gateway | string | `"v2.0.18"` |  |
-| versions.files."v2.0".ledger | string | `"v2.0.18"` |  |
-| versions.files."v2.0".operator-utils | string | `"v2.0.18"` |  |
-| versions.files."v2.0".orchestration | string | `"v2.0.18"` |  |
-| versions.files."v2.0".payments | string | `"v2.0.18"` |  |
-| versions.files."v2.0".reconciliation | string | `"v2.0.18"` |  |
-| versions.files."v2.0".search | string | `"v2.0.18"` |  |
-| versions.files."v2.0".stargate | string | `"v2.0.18"` |  |
-| versions.files."v2.0".wallets | string | `"v2.0.18"` |  |
-| versions.files."v2.0".webhooks | string | `"v2.0.18"` |  |
-| versions.files."v2.1".auth | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".gateway | string | `"v2.1.0-beta.3"` |  |
-| versions.files."v2.1".ledger | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".operator-utils | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".orchestration | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".payments | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".reconciliation | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".search | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".stargate | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".wallets | string | `"v2.1.0-beta.4"` |  |
-| versions.files."v2.1".webhooks | string | `"v2.1.0-beta.4"` |  |
+| versions.files."v2.0".auth | string | `"v2.0.20"` |  |
+| versions.files."v2.0".gateway | string | `"v2.0.20"` |  |
+| versions.files."v2.0".ledger | string | `"v2.0.20"` |  |
+| versions.files."v2.0".operator-utils | string | `"v2.0.20"` |  |
+| versions.files."v2.0".orchestration | string | `"v2.0.20"` |  |
+| versions.files."v2.0".payments | string | `"v2.0.20"` |  |
+| versions.files."v2.0".reconciliation | string | `"v2.0.20"` |  |
+| versions.files."v2.0".search | string | `"v2.0.20"` |  |
+| versions.files."v2.0".stargate | string | `"v2.0.20"` |  |
+| versions.files."v2.0".wallets | string | `"v2.0.20"` |  |
+| versions.files."v2.0".webhooks | string | `"v2.0.20"` |  |
+| versions.files."v2.1".auth | string | `"v2.0.20"` |  |
+| versions.files."v2.1".gateway | string | `"v2.0.20"` |  |
+| versions.files."v2.1".ledger | string | `"v2.1.0"` |  |
+| versions.files."v2.1".operator-utils | string | `"v2.0.20"` |  |
+| versions.files."v2.1".orchestration | string | `"v2.0.20"` |  |
+| versions.files."v2.1".payments | string | `"v2.0.20"` |  |
+| versions.files."v2.1".reconciliation | string | `"v2.0.20"` |  |
+| versions.files."v2.1".search | string | `"v2.0.20"` |  |
+| versions.files."v2.1".stargate | string | `"v2.0.20"` |  |
+| versions.files."v2.1".wallets | string | `"v2.0.20"` |  |
+| versions.files."v2.1".webhooks | string | `"v2.0.20"` |  |
 | versions.files.default.auth | string | `"v0.4.4"` |  |
 | versions.files.default.gateway | string | `"v2.0.18"` |  |
 | versions.files.default.ledger | string | `"v1.10.14"` |  |

--- a/charts/regions/values.yaml
+++ b/charts/regions/values.yaml
@@ -79,26 +79,26 @@ versions:
       ledger: v1.10.14
       operator-utils: v2.0.18
     v2.0:
-      ledger: v2.0.18
-      search: v2.0.18
-      stargate: v2.0.18
-      auth: v2.0.18
-      wallets: v2.0.18
-      webhooks: v2.0.18
-      gateway: v2.0.18
-      payments: v2.0.18
-      orchestration: v2.0.18
-      reconciliation: v2.0.18
-      operator-utils: v2.0.18
+      ledger: v2.0.20
+      search: v2.0.20
+      stargate: v2.0.20
+      auth: v2.0.20
+      wallets: v2.0.20
+      webhooks: v2.0.20
+      gateway: v2.0.20
+      payments: v2.0.20
+      orchestration: v2.0.20
+      reconciliation: v2.0.20
+      operator-utils: v2.0.20
     v2.1:
-      ledger: v2.1.0-beta.4
-      search: v2.1.0-beta.4
-      stargate: v2.1.0-beta.4
-      auth: v2.1.0-beta.4
-      wallets: v2.1.0-beta.4
-      webhooks: v2.1.0-beta.4
-      gateway: v2.1.0-beta.3
-      payments: v2.1.0-beta.4
-      orchestration: v2.1.0-beta.4
-      reconciliation: v2.1.0-beta.4
-      operator-utils: v2.1.0-beta.4
+      ledger: v2.1.0
+      search: v2.0.20
+      stargate: v2.0.20
+      auth: v2.0.20
+      wallets: v2.0.20
+      webhooks: v2.0.20
+      gateway: v2.0.20
+      payments: v2.0.20
+      orchestration: v2.0.20
+      reconciliation: v2.0.20
+      operator-utils: v2.0.20


### PR DESCRIPTION
Update Chart.yaml to version 2.1.2 and operator dependency to 2.0.20. Update values.yaml with new versions for services in v2.0 and v2.1.