### PR TITLE
chore: bump Regions chart to version 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [Demo](./charts/demo/README.md) | 2.0.0 |latest | Formance Private Regions Demo | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/demo)](https://artifacthub.io/packages/search?repo=demo) |
 | [Membership](./charts/membership/README.md) | v1.0.0-beta.27 |v0.36.2 | Formance Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | v1.0.0-beta.20 |191a441519a65dae56a5b2cf56fe64eee03fc059 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | v2.5.4 |latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | v2.6.0 |latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.5.10 |latest | Formance Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v2.3.2
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
-  version: v2.3.1
-digest: sha256:4ee50a012925ce0b01ce18740220ad45fd5a1c3c340435b25a60c9f3d027b2cd
-generated: "2024-12-17T12:10:02.724021+01:00"
+  version: v2.5.1
+digest: sha256:038291e070ac231f816c6ce611a1f59dbe4c7599fa2a3d6833cdc18323bdf5e2
+generated: "2025-01-07T09:38:27.705928223Z"

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: "v2.5.4"
+version: "v2.6.0"
 appVersion: "latest"
 
 dependencies:
@@ -20,6 +20,6 @@ dependencies:
     repository: "file://../agent"
     condition: agent.enabled
   - name: operator
-    version: v2.3.1
+    version: v2.5.1
     repository: "oci://ghcr.io/formancehq/helm"
     condition: operator.enabled

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # regions
 
-![Version: v2.5.4](https://img.shields.io/badge/Version-v2.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: v2.6.0](https://img.shields.io/badge/Version-v2.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Private Regions Helm Chart
 
@@ -22,7 +22,7 @@ Formance Private Regions Helm Chart
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../agent | agent | v2.3.2 |
-| oci://ghcr.io/formancehq/helm | operator | v2.3.1 |
+| oci://ghcr.io/formancehq/helm | operator | v2.5.1 |
 
 ## Values
 


### PR DESCRIPTION
Updated the Regions Helm Chart to version 2.6.0 and upgraded the Operator dependency to version 2.5.1. These changes reflect improvements and potential fixes in the chart and its dependencies. Ensure compatibility before deploying.