### PR TITLE
feat: Update regions chart to version 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [Demo](./charts/demo/README.md) | 2.1.0 | latest | Formance Private Regions Demo | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/demo)](https://artifacthub.io/packages/search?repo=demo) |
 | [Membership](./charts/membership/README.md) | 2.2.2 | v1.1.1 | Formance Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | 2.0.5 | 5e7b404a3a208b1f38603719e02a8b1883c10acf | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | 2.8.4 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | 3.0.0 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.6.1 | latest | Formance Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [Demo](./charts/demo/README.md) | 2.1.0 | latest | Formance Private Regions Demo | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/demo)](https://artifacthub.io/packages/search?repo=demo) |
 | [Membership](./charts/membership/README.md) | 2.2.2 | v1.1.1 | Formance Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | 2.0.5 | 5e7b404a3a208b1f38603719e02a8b1883c10acf | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | 3.0.0 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | 2.9.0 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.6.1 | latest | Formance Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.4.1
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
-  version: v2.6.0
-digest: sha256:72eccae222d27466817cb2dedb8cacbce157ae43255d79fc194ad4fe99133830
-generated: "2025-02-05T11:19:12.47191+01:00"
+  version: v2.7.0
+digest: sha256:c62b6fadbb1cf1fe7c56deea49ac910664f0e76c12bb98b2a427d71e22151f06
+generated: "2025-02-10T09:39:15.107915764Z"

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 2.8.4
+version: 3.0.0
 appVersion: "latest"
 
 dependencies:
@@ -20,6 +20,6 @@ dependencies:
   repository: "file://../agent"
   condition: agent.enabled
 - name: operator
-  version: v2.6.0
+  version: v2.7.0
   repository: "oci://ghcr.io/formancehq/helm"
   condition: operator.enabled

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 3.0.0
+version: 2.9.0
 appVersion: "latest"
 
 dependencies:

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # regions
 
-![Version: 2.8.4](https://img.shields.io/badge/Version-2.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Private Regions Helm Chart
 
@@ -22,7 +22,7 @@ Formance Private Regions Helm Chart
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../agent | agent | 2.X |
-| oci://ghcr.io/formancehq/helm | operator | v2.6.0 |
+| oci://ghcr.io/formancehq/helm | operator | v2.7.0 |
 
 ## Values
 
@@ -107,6 +107,17 @@ Formance Private Regions Helm Chart
 | versions.files."v2.1".stargate | string | `"v2.0.24"` |  |
 | versions.files."v2.1".wallets | string | `"v2.1.1"` |  |
 | versions.files."v2.1".webhooks | string | `"v2.1.0"` |  |
+| versions.files."v3.0".auth | string | `"v2.1.1"` |  |
+| versions.files."v3.0".gateway | string | `"v2.1.0"` |  |
+| versions.files."v3.0".ledger | string | `"v2.2.0"` |  |
+| versions.files."v3.0".operator-utils | string | `"v2.0.24"` |  |
+| versions.files."v3.0".orchestration | string | `"v2.1.0"` |  |
+| versions.files."v3.0".payments | string | `"v3.0.0"` |  |
+| versions.files."v3.0".reconciliation | string | `"v2.1.0"` |  |
+| versions.files."v3.0".search | string | `"v2.1.0"` |  |
+| versions.files."v3.0".stargate | string | `"v2.1.0"` |  |
+| versions.files."v3.0".wallets | string | `"v2.1.1"` |  |
+| versions.files."v3.0".webhooks | string | `"v2.1.0"` |  |
 | versions.files.default.auth | string | `"v0.4.4"` |  |
 | versions.files.default.gateway | string | `"v2.0.18"` |  |
 | versions.files.default.ledger | string | `"v1.10.14"` |  |

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # regions
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Private Regions Helm Chart
 

--- a/charts/regions/values.schema.json
+++ b/charts/regions/values.schema.json
@@ -295,6 +295,44 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        "v3.0": {
+                            "properties": {
+                                "auth": {
+                                    "type": "string"
+                                },
+                                "gateway": {
+                                    "type": "string"
+                                },
+                                "ledger": {
+                                    "type": "string"
+                                },
+                                "operator-utils": {
+                                    "type": "string"
+                                },
+                                "orchestration": {
+                                    "type": "string"
+                                },
+                                "payments": {
+                                    "type": "string"
+                                },
+                                "reconciliation": {
+                                    "type": "string"
+                                },
+                                "search": {
+                                    "type": "string"
+                                },
+                                "stargate": {
+                                    "type": "string"
+                                },
+                                "wallets": {
+                                    "type": "string"
+                                },
+                                "webhooks": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
                         }
                     },
                     "type": "object"

--- a/charts/regions/values.yaml
+++ b/charts/regions/values.yaml
@@ -103,3 +103,15 @@ versions:
       orchestration: v2.0.24
       reconciliation: v2.0.24
       operator-utils: v2.0.24
+    v3.0:
+      payments: v3.0.0
+      ledger: v2.2.0
+      search: v2.1.0
+      stargate: v2.1.0
+      auth: v2.1.1
+      wallets: v2.1.1
+      webhooks: v2.1.0
+      gateway: v2.1.0
+      orchestration: v2.1.0
+      reconciliation: v2.1.0
+      operator-utils: v2.0.24


### PR DESCRIPTION
Bumped the regions chart version from 2.8.4 to 3.0.0 and updated dependencies, including operator to v2.7.0. Introduced new versions map for v3.0 with specific component versions. Updated README and schema to reflect these changes.