### PR TITLE
feat: create K8s Secret for licence token

### DIFF
--- a/charts/core/templates/_licence.tpl
+++ b/charts/core/templates/_licence.tpl
@@ -1,26 +1,17 @@
-{{/** 
+{{/**
   global:
-    # Add your license information 
     licence:
-      # -- Obtain your licence cluster id with `kubectl get ns kube-system -o jsonpath='{.metadata.uid}'`
-      # @section -- Licence configuration
+      createSecret: true
       clusterID: ""
-      # -- Licence Environment 
-      # @section -- Licence configuration
       issuer: "https://license.formance.cloud/keys"
-      # -- Licence Client Token delivered by contacting [Formance](https://formance.com)
-      # @section -- Licence configuration
       token: ""
-      # -- Licence Client Token as a secret
-      # @section -- Licence configuration
       existingSecret: ""
       secretKeys:
-        # -- Key in existing secret to use for Licence Client Token
-        # @section -- Licence configuration
-        token: ""
-    
+        token: "token"
+
   config:
     licence:
+      createSecret: true
       clusterID: ""
       issuer: ""
       token: ""
@@ -31,19 +22,33 @@
 {{- define "core.licence.env" }}
 {{- $enabled := include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.enabled" "Default" "true") -}}
 {{- if eq $enabled "true" }}
+{{- $existingSecret := include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.existingSecret" "Default" "") -}}
+{{- $createSecret := include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.createSecret" "Default" "false") -}}
+{{- $secretName := "" -}}
+{{- if $existingSecret -}}
+  {{- $secretName = $existingSecret -}}
+{{- else if eq $createSecret "true" -}}
+  {{- $secretName = printf "%s-licence" .Release.Name -}}
+{{- end }}
 - name: LICENCE_TOKEN
-  {{- $value := include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.existingSecret" "Default" "") -}}
-  {{- if $value }}
+  {{- if $secretName }}
   valueFrom:
     secretKeyRef:
-      name: {{ $value | quote }}
-      key: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.secretKeys.token" "Default" "") | quote }}
+      name: {{ $secretName | quote }}
+      key: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.secretKeys.token" "Default" "token") | quote }}
   {{- else }}
   value: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.token" "Default" "") | quote }}
   {{- end }}
 - name: LICENCE_CLUSTER_ID
-  value: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.clusterID" "Default" "") | quote}}
+  value: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.clusterID" "Default" "") | quote }}
 - name: LICENCE_ISSUER
-  value: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.issuer" "Default" "") | quote}}
+  {{- if $secretName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName | quote }}
+      key: "issuer"
+  {{- else }}
+  value: {{ include "resolveGlobalOrServiceValue" (dict "Context" . "Key" "licence.issuer" "Default" "") | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.4.0
+  version: 18.5.1
 - name: regions
   repository: file://../regions
   version: 3.7.3
 - name: cloudprem
   repository: file://../cloudprem
   version: 4.0.0
-digest: sha256:51423794def4b4d9d26bb8c62066ecd268ec297e27592c67acc496a1f54260ee
-generated: "2026-02-24T12:39:46.631725+01:00"
+digest: sha256:aa1a75780ee4cbb9b056e42991cc05ec29e80cb44ddec7dc0076e894d7cb3afe
+generated: "2026-02-26T13:31:37.756317+01:00"

--- a/charts/formance/templates/licence-secret.yaml
+++ b/charts/formance/templates/licence-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.licence.createSecret .Values.global.licence.token }}
+{{- $secretName := .Values.global.licence.existingSecret | default (printf "%s-licence" .Release.Name) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "formance.labels" . | nindent 4 }}
+    formance.com/stack: any
+stringData:
+  token: {{ .Values.global.licence.token | quote }}
+  issuer: {{ .Values.global.licence.issuer | quote }}
+{{- end }}

--- a/charts/formance/values.yaml
+++ b/charts/formance/values.yaml
@@ -32,7 +32,9 @@ global:
   # -- Licence configuration (REQUIRED when ee.enabled=true)
   # @section -- Licence configuration
   licence:
-    # -- Create licence secret
+    # -- Create a K8s Secret for the licence token.
+    # When true, the chart creates a Secret containing the token and issuer.
+    # To share this Secret with the Operator, also set existingSecret to '<release-name>-licence'.
     # @section -- Licence configuration
     createSecret: true
     # -- Cluster ID: kubectl get ns kube-system -o jsonpath='{.metadata.uid}'
@@ -44,7 +46,8 @@ global:
     # -- Licence token from Formance
     # @section -- Licence configuration
     token: ""
-    # -- Use existing secret for licence token
+    # -- Use an existing secret for licence. When set with createSecret=true,
+    # the created secret uses this name (enabling sharing with the Operator).
     # @section -- Licence configuration
     existingSecret: ""
     secretKeys:

--- a/charts/membership/Chart.lock
+++ b/charts/membership/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.4.0
+  version: 18.5.1
 - name: dex
   repository: https://charts.dexidp.io
   version: 0.17.1
 - name: core
   repository: file://../core
   version: 1.5.0
-digest: sha256:f8a0b1d6bbc5adc33f518585e7739653f3aa2c7c38ee9e8b96fa1221918c430c
-generated: "2026-02-18T11:17:47.658572+01:00"
+digest: sha256:bb61fce3a80be6c1c593b6c7d070ec1513b12dd67aba2d24ebf61903549d4fa1
+generated: "2026-02-26T13:31:20.163366+01:00"

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.12.1
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
-  version: 3.6.0
+  version: 3.7.1
 - name: core
   repository: file://../core
   version: 1.5.0
-digest: sha256:9b3b796ce82738311c852da7499aadee8565a4b333418b2079f889c81a33f3bb
-generated: "2026-02-24T12:38:17.970095+01:00"
+digest: sha256:19588f2e7ebf22b62a4cb6091e646546713d8391b9d10732dac535e4224e197c
+generated: "2026-02-26T13:31:30.59737+01:00"


### PR DESCRIPTION
## Summary

- **New template** `licence-secret.yaml`: creates a K8s Secret (`<release>-licence`) containing `token` and `issuer` when `global.licence.createSecret=true` and `token` is non-empty
- **Updated `core.licence.env` helper**: 3-tier resolution for `LICENCE_TOKEN` and `LICENCE_ISSUER` — `existingSecret` > `createSecret` auto-name > plain value fallback
- **Improved values.yaml docs**: explains how to share the Secret with the Operator via `existingSecret`

### Usage modes

| Mode | Values | Result |
|------|--------|--------|
| **Auto** | `createSecret: true`, `token: xxx` | Creates `<release>-licence`, Operator creates its own |
| **Shared** | `createSecret: true`, `token: xxx`, `existingSecret: <release>-licence` | Creates `<release>-licence`, Operator reuses it |
| **Manual** | `createSecret: false`, `existingSecret: my-secret` | No secret created, both reference `my-secret` |
| **Legacy** | `createSecret: false`, `token: xxx` | No secret, token as plain env var |

## Test plan

- [x] `helm template` with `createSecret=true` + `token` → Secret rendered with `secretKeyRef` in env vars
- [x] `helm template` with `existingSecret` set → Secret uses custom name
- [x] `helm template` without token → no Secret created
- [x] `helm template` with `createSecret=false` → legacy plain value fallback
- [x] `helm lint` passes in both CE and EE modes
- [x] Full render (CE + EE) produces valid YAML without errors