### PR TITLE
fix(regions): bump deprecated version threshold to v2.2.0

### DIFF
--- a/charts/console-v3/Chart.lock
+++ b/charts/console-v3/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.5.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.6.3
-digest: sha256:5f68fa2527f3880c20a25fe82996dc758da8477efdbe7b1c6244f8518f18f88e
-generated: "2026-05-08T03:02:21.705399728Z"
+  version: 18.6.4
+digest: sha256:af96afc609cb31ddd959fcb2c75ea4157da09db188fbb17af896b63439de65dc
+generated: "2026-05-11T11:42:00.005023+02:00"

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.6.3
+  version: 18.6.4
 - name: regions
   repository: file://../regions
   version: 3.9.4
 - name: cloudprem
   repository: file://../cloudprem
   version: 4.6.2
-digest: sha256:af4766b870d86e08f5bdc3a025c34a4a064c6be928353cb071b1a716add8ef69
-generated: "2026-05-08T03:02:24.839006459Z"
+digest: sha256:2858f204797c53075ecb9f1c6131ca10856a4f321fc4ab2676bda93f8c56ebab
+generated: "2026-05-11T11:42:02.217925+02:00"

--- a/charts/membership/Chart.lock
+++ b/charts/membership/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.6.3
+  version: 18.6.4
 - name: dex
   repository: https://charts.dexidp.io
   version: 0.24.0
 - name: core
   repository: file://../core
   version: 1.5.1
-digest: sha256:5feff9057011b5f6a9aadc784fea77623daa1299c5fc6943d2fd322d108fcdbe
-generated: "2026-05-08T03:02:07.58998779Z"
+digest: sha256:0a1adf64f85ec0ab8f831a08cd363da2298fb390afd8af21a3727c318c999c83
+generated: "2026-05-11T11:41:55.819219+02:00"

--- a/charts/portal/Chart.lock
+++ b/charts/portal/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.5.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.6.3
-digest: sha256:5f68fa2527f3880c20a25fe82996dc758da8477efdbe7b1c6244f8518f18f88e
-generated: "2026-05-08T03:02:21.335943459Z"
+  version: 18.6.4
+digest: sha256:af96afc609cb31ddd959fcb2c75ea4157da09db188fbb17af896b63439de65dc
+generated: "2026-05-11T11:41:46.57987+02:00"

--- a/charts/regions/templates/versions.yaml
+++ b/charts/regions/templates/versions.yaml
@@ -14,7 +14,7 @@ metadata:
     formance.com/deprecated: "true"
   {{- end }}
   {{- else }}
-  {{- if gt (semver $key | (semver "v2.0.0").Compare) 0 }}
+  {{- if gt (semver $key | (semver "v2.2.0").Compare) 0 }}
     formance.com/deprecated: "true"
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## Summary
- Bump the semver threshold for the `formance.com/deprecated` annotation from `v2.0.0` to `v2.2.0` in the `Versions` CRD template
- Versions below `v2.2.0` are now marked as deprecated
- Chart version bumped to `3.8.2`

## Test plan
- [x] `just pc` passes (lint, schema generation, template rendering)