### PR TITLE
feat: import shared helm recipes from formancehq/just-lib

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,6 +9,9 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ inputs.token }}
     - name: Cache dependencies
       uses: nix-community/cache-nix-action@v7
       with:
@@ -25,3 +28,6 @@ runs:
         key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-${{ github.job }}-go-
+    - name: Warm nix shell
+      shell: bash
+      run: nix develop --impure --command true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ charts/**/LICENSE
 .ci
 
 docs
+.just-lib

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,9 @@
 set dotenv-load
 set positional-arguments
 
+import '.just-lib/helm/recipes.just'
+export HELM_DIR := "charts"
+
 default:
   @just --list
 
@@ -13,46 +16,6 @@ lint:
 tidy: lint
   @cd ./tools/readme && go mod tidy
 
-helm-schema-install:
-  helm plugin install https://github.com/losisin/helm-values-schema-json.git --version v1.9.2 || true
-
-helm-schema path='':
-  helm schema -input {{path}}/values.yaml -output {{path}}/values.schema.json
-  
-helm-docs:
-  go run github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14 --chart-search-root=charts --document-dependency-values --skip-version-footer
-
-helm-all package="false" publish='false' packageArgs="": helm-docs helm-schema-install
-  #!/bin/bash
-  set -euo pipefail
-
-  charts=$(find ./charts -name Chart.yaml | xargs -n1 dirname)
-
-  # Phase 1: Update dependencies sequentially to avoid race conditions on shared subcharts
-  for chart in $charts; do
-    just helm-schema "$chart"
-    just helm-update "$chart"
-  done
-
-  # Phase 2: Lint, template, and package in parallel (dependencies are already resolved)
-  for chart in $charts; do
-    (
-      if [ "{{package}}" = "true" ]; then
-        just helm-package-only "$chart" {{packageArgs}}
-      else
-        just helm-template-only "$chart"
-      fi
-    ) &
-  done
-  wait
-  if [ "{{publish}}" = "true" ]; then
-    for chart in $(find ./build -name "*.tgz"); do
-      (
-        just helm-publish "$chart"
-      ) 
-    done
-  fi
-
 template-readme: tidy
   #!/bin/bash
   pushd ./tools/readme
@@ -61,100 +24,6 @@ template-readme: tidy
   go run ./ \
     --template-file contributing.tpl > ../../CONTRIBUTING.md
   popd
-
-helm-update path='' args='': helm-login
-  #!/bin/bash
-  set -e
-
-  update_chart() {
-    local chart_dir="$1"
-
-    echo "🔍 Checking $chart_dir"
-
-    if [[ ! -f "$chart_dir/Chart.yaml" ]]; then
-      echo "❌ No Chart.yaml in $chart_dir"
-      return
-    fi
-
-    local deps
-    deps=$(helm dependency list "$chart_dir" 2>/dev/null | grep 'file://' | awk '{print $1, $2, $3}' || true)
-
-    while read -r name version repo; do
-      if [[ "$repo" == file://* ]]; then
-        local subchart_path
-        subchart_path=$(echo "$repo" | sed 's|file://||')
-        local full_path="$chart_dir/$subchart_path"
-        update_chart "$full_path"
-      fi
-    done <<< "$deps"
-
-    echo "🔗 helm dependency update $chart_dir {{args}}"
-    helm dependency update "$chart_dir" {{args}} > /dev/null
-  }
-
-  update_chart {{path}}
-
-helm-lint path='' args="":
-  #!/bin/bash
-  set -euo pipefail
-  just helm-update {{path}}
-  echo "📝 Linting chart {{path}}"
-  helm lint {{path}} --strict
-
-helm-template path='' args='' output='/dev/null':
-  #!/bin/bash
-  set -euo pipefail
-  just helm-lint {{path}}
-
-  isLibrary=$(yq -r '.type' {{path}}/Chart.yaml)
-  echo "Chart type: $isLibrary"
-  if [ "$isLibrary" = "library" ]; then
-    echo "❌ Skipping template for library chart"
-  else
-    echo "✨ Rendering chart {{path}} on {{output}}"
-    helm template {{path}} {{args}} > {{output}}
-  fi
-
-helm-template-only path='' args='' output='/dev/null':
-  #!/bin/bash
-  set -euo pipefail
-  echo "📝 Linting chart {{path}}"
-  helm lint {{path}} --strict
-
-  isLibrary=$(yq -r '.type' {{path}}/Chart.yaml)
-  echo "Chart type: $isLibrary"
-  if [ "$isLibrary" = "library" ]; then
-    echo "❌ Skipping template for library chart"
-  else
-    echo "✨ Rendering chart {{path}} on {{output}}"
-    helm template {{path}} {{args}} > {{output}}
-  fi
-
-helm-package path='' args='':
-  just helm-template {{path}}
-  helm package {{path}} --destination ./build {{args}}
-
-helm-package-only path='' args='':
-  #!/bin/bash
-  set -euo pipefail
-  echo "📝 Linting chart {{path}}"
-  helm lint {{path}} --strict
-
-  isLibrary=$(yq -r '.type' {{path}}/Chart.yaml)
-  echo "Chart type: $isLibrary"
-  if [ "$isLibrary" = "library" ]; then
-    echo "❌ Skipping template for library chart"
-  else
-    echo "✨ Rendering chart {{path}}"
-    helm template {{path}} > /dev/null
-  fi
-  helm package {{path}} --destination ./build {{args}}
-
-helm-publish path='': helm-login
-  helm push {{path}} oci://ghcr.io/formancehq/helm
-
-helm-login:
-  echo $GITHUB_TOKEN | helm registry login ghcr.io -u NumaryBot --password-stdin || true
 
 release:
   #!/bin/bash

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,23 @@
         "type": "github"
       }
     },
+    "just-lib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775050988,
+        "narHash": "sha256-8JEACb/nm2o3pWQtSB3axaLnTpPPvDT03GvR5DHihQA=",
+        "owner": "formancehq",
+        "repo": "just-lib",
+        "rev": "5708b133512d8670e29920819a80acd4c192ee28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "formancehq",
+        "ref": "feat/actions-and-tests",
+        "repo": "just-lib",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1742422364,
@@ -59,6 +76,7 @@
     },
     "root": {
       "inputs": {
+        "just-lib": "just-lib",
         "nixpkgs": "nixpkgs",
         "nur": "nur"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,11 @@
       url = "github:nix-community/NUR";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    just-lib = { url = "git+ssh://git@github.com/formancehq/just-lib"; flake = false; };
   };
 
-  outputs = { self, nixpkgs, nur }:
+  outputs = { self, nixpkgs, nur, just-lib }:
     let
       goVersion = 23;
 
@@ -42,6 +44,9 @@
       devShells = forEachSupportedSystem ({ pkgs, system }:
         {
           default = pkgs.mkShell {
+            shellHook = ''
+              ln -sfn ${just-lib} .just-lib
+            '';
             packages = with pkgs; [
               go
               gotools
@@ -49,11 +54,11 @@
               ginkgo
               pkgs.nur.repos.goreleaser.goreleaser-pro
               just
-              kubernetes-helm
               kustomize_4
               mockgen
               yq
-            ];
+            ]
+            ++ (import "${just-lib}/helm/pkgs.nix" { inherit pkgs; });
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    just-lib = { url = "git+ssh://git@github.com/formancehq/just-lib"; flake = false; };
+    just-lib = { url = "github:formancehq/just-lib/feat/actions-and-tests"; flake = false; };
   };
 
   outputs = { self, nixpkgs, nur, just-lib }:


### PR DESCRIPTION
## Summary
Import shared Helm recipes from [formancehq/just-lib](https://github.com/formancehq/just-lib).

### Changes
- `flake.nix`: added just-lib input, helm pkgs from library
- `Justfile`: import shared helm recipes, removed inline helm recipes
- `.gitignore`: added `.just-lib`

### New recipes from library
- `helm-deps` — build deps, schema, docs
- `helm-test` — datree validation
- `helm-push` / `helm-push-dev` — push to production/dev registry
- `helm-publish` / `helm-publish-dev` — full publish flow
- `helm-version` — stamp version on charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)