### PR TITLE
chore: bump console-v3 and portal to v2.3.1

### DIFF
--- a/charts/cloudprem/Chart.lock
+++ b/charts/cloudprem/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 3.2.0
 - name: portal
   repository: file://../portal
-  version: 3.3.0
+  version: 3.3.1
 - name: console-v3
   repository: file://../console-v3
-  version: 3.3.0
-digest: sha256:03b33ee401e582126bc1fc84dfc76b9cefb067ab8683ea124bfde18e7b2adf5d
-generated: "2026-04-09T10:58:35.069891+02:00"
+  version: 3.3.1
+digest: sha256:443f71291b973e98b395e398cd908ee2926f852e91ef0c72b79ee31dd516dfdd
+generated: "2026-04-20T14:41:53.555112+02:00"

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.5.0
+version: 4.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,7 +1,7 @@
 # Formance cloudprem Helm chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem)
-![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 4.5.1](https://img.shields.io/badge/Version-4.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance control-plane
 

--- a/charts/console-v3/Chart.lock
+++ b/charts/console-v3/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.5.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.5.20
-digest: sha256:89b7907066f512f185dad8aa222aeb25eac9f1530401ef005d22937b574c07d1
-generated: "2026-04-16T03:02:05.620982309Z"
+  version: 18.5.24
+digest: sha256:e5db92b79cb0c280e4046bfd53a2b4a6e5e1140ce6f5369d9a1c96ed1d4ad5c7
+generated: "2026-04-20T14:41:53.084429+02:00"

--- a/charts/console-v3/Chart.yaml
+++ b/charts/console-v3/Chart.yaml
@@ -29,13 +29,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.3.0"
+appVersion: "v2.3.1"
 # The "-0" suffix is required for GKE compatibility. GKE versions contain
 # build metadata like "v1.33.5-gke.2392000" which semver treats as pre-release.
 # Without "-0", Helm rejects these versions as incompatible.

--- a/charts/console-v3/README.md
+++ b/charts/console-v3/README.md
@@ -1,6 +1,6 @@
 # console-v3
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.1](https://img.shields.io/badge/AppVersion-v2.3.1-informational?style=flat-square)
 
 Formance Console
 

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.5.20
+  version: 18.5.24
 - name: regions
   repository: file://../regions
   version: 3.8.5
 - name: cloudprem
   repository: file://../cloudprem
-  version: 4.5.0
-digest: sha256:087858fbd753777d933f3f6bcf61767d6033f34683d69fe75242d5a961a58983
-generated: "2026-04-16T03:02:14.265710661Z"
+  version: 4.5.1
+digest: sha256:5699ba189a9b808d19b92cd52e92e61fecaf74bf9c3967b17b4d31e0ff502673
+generated: "2026-04-20T14:41:54.541162+02:00"

--- a/charts/formance/Chart.yaml
+++ b/charts/formance/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 1.7.0
+version: 1.6.1
 appVersion: "latest"
 # The "-0" suffix is required for GKE compatibility. GKE versions contain
 # build metadata like "v1.33.5-gke.2392000" which semver treats as pre-release.

--- a/charts/formance/README.md
+++ b/charts/formance/README.md
@@ -1,6 +1,6 @@
 # formance
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Platform - Unified Helm Chart
 

--- a/charts/membership/Chart.lock
+++ b/charts/membership/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.5.20
+  version: 18.5.24
 - name: dex
   repository: https://charts.dexidp.io
   version: 0.17.1
 - name: core
   repository: file://../core
   version: 1.5.1
-digest: sha256:59c28546eb0e613f535789102ce57d59630860884050b9310523981ad4cf5de3
-generated: "2026-04-16T03:02:03.304260325Z"
+digest: sha256:3eda93ee454ec33564a9824afbe48646e5cae2889222bb3bcbf30bd9d2c85c62
+generated: "2026-04-20T14:41:49.901538+02:00"

--- a/charts/portal/Chart.lock
+++ b/charts/portal/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.5.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.5.20
-digest: sha256:89b7907066f512f185dad8aa222aeb25eac9f1530401ef005d22937b574c07d1
-generated: "2026-04-16T03:02:01.282138287Z"
+  version: 18.5.24
+digest: sha256:e5db92b79cb0c280e4046bfd53a2b4a6e5e1140ce6f5369d9a1c96ed1d4ad5c7
+generated: "2026-04-20T14:41:40.750771+02:00"

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -26,13 +26,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.3.0"
+appVersion: "v2.3.1"
 # The "-0" suffix is required for GKE compatibility. GKE versions contain
 # build metadata like "v1.33.5-gke.2392000" which semver treats as pre-release.
 # Without "-0", Helm rejects these versions as incompatible.

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -1,6 +1,6 @@
 # portal
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.1](https://img.shields.io/badge/AppVersion-v2.3.1-informational?style=flat-square)
 
 Formance Portal
 


### PR DESCRIPTION
## Summary
- Bump console-v3 chart to 3.3.1 (appVersion: v2.3.1)
- Bump portal chart to 3.3.1 (appVersion: v2.3.1)
- Bump cloudprem chart to 4.5.1
- Bump formance chart to 1.6.1

## Related
- platform-ui release: https://github.com/formancehq/platform-ui/releases/tag/console-v3/v2.3.1