### PR TITLE
chore: install helm-schema plugin via nix

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,16 +13,13 @@ lint:
 tidy: lint
   @cd ./tools/readme && go mod tidy
 
-helm-schema-install:
-  helm plugin install https://github.com/losisin/helm-values-schema-json.git --version v1.9.2 || true
-
 helm-schema path='':
-  helm schema -input {{path}}/values.yaml -output {{path}}/values.schema.json
+  helm schema --values {{path}}/values.yaml --output {{path}}/values.schema.json
   
 helm-docs:
   go run github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14 --chart-search-root=charts --document-dependency-values --skip-version-footer
 
-helm-all package="false" publish='false' packageArgs="": helm-docs helm-schema-install
+helm-all package="false" publish='false' packageArgs="": helm-docs
   #!/bin/bash
   set -euo pipefail
 

--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
-        "revCount": 770807,
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "revCount": 911667,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.770807%2Brev-a84ebe20c6bc2ecbcfb000a50776219f48d134cc/0195b626-8c1d-7fb9-9282-563af3d37ab9/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.911667%2Brev-a4bf06618f0b5ee50f14ed8f0da77d34ecc19160/019dcae8-75b0-71d1-abd5-feab9658f0fa/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511.%2A.tar.gz"
       }
     },
     "nur": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Wallets dev env";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2511.*.tar.gz";
 
     nur = {
       url = "github:nix-community/NUR";
@@ -12,7 +12,7 @@
 
   outputs = { self, nixpkgs, nur }:
     let
-      goVersion = 23;
+      goVersion = 26;
 
       supportedSystems = [
         "x86_64-linux"
@@ -49,7 +49,9 @@
               ginkgo
               pkgs.nur.repos.goreleaser.goreleaser-pro
               just
-              kubernetes-helm
+              (wrapHelm kubernetes-helm {
+                plugins = [ kubernetes-helmPlugins.helm-schema ];
+              })
               kustomize_4
               mockgen
               yq


### PR DESCRIPTION
## Summary

- Move the `helm-values-schema-json` plugin out of `helm plugin install` and into the dev shell via `wrapHelm` so its version is pinned in `flake.lock` alongside everything else
- Update the `helm-schema` recipe to use the v2.x cobra flag syntax (`--values`/`--output`); the legacy `-input`/`-output` form was silently broken once the on-disk binary drifted past v2.0
- Bump nixpkgs to 25.11 (`0.2511.*`) so `kubernetes-helmPlugins.helm-schema` is available, and bump `goVersion` to 26 (go 1.23 was removed as EOL in newer nixpkgs)

## Why

`helm plugin install … --version vX.Y.Z || true` no-ops when the plugin is already installed, so the install hook never re-runs and the binary stays on whatever was last fetched. That's how `just pc` ended up calling a cobra-based v2 binary with v1 flags. Owning the plugin in nix removes that whole drift class.

## Test plan

- [x] `nix develop --command helm plugin list` shows `schema 2.3.0`
- [x] `nix develop --command just helm-schema ./charts/regions` succeeds with new flags
- [x] Re-ran `helm schema` against all 9 charts — every one generates cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)