### PR TITLE
chore(ci): migrate from Shipfox to Namespace.so runners

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,19 +9,11 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
-    - name: Cache dependencies
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.nix', '**/flake.lock') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-
     - name: Load dependencies
       shell: bash
       run: nix develop --install
-    - uses: actions/cache@v5
+    - uses: namespacelabs/nscloud-cache-action@v1
       with:
         path: |
           ~/.cache/go-build
           /tmp/go/pkg/mod/
-        key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.job }}-go-

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,9 +12,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: shipfox-2vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-2vcpu
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "namespacelabs/nscloud-checkout-action@v7"
         with:
           fetch-depth: 0
       - uses: actions/labeler@v6
@@ -50,7 +50,7 @@ jobs:
   pr_name:
     if: github.event_name == 'pull_request'
     name: Check PR Title
-    runs-on: shipfox-2vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-2vcpu
     permissions:
       statuses: write
     steps:
@@ -58,9 +58,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   Dirty:
-    runs-on: shipfox-4vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-4vcpu
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "namespacelabs/nscloud-checkout-action@v7"
         with:
           fetch-depth: 0
       - name: Setup Nix
@@ -84,9 +84,9 @@ jobs:
           fi
 
   Artifacts:
-    runs-on: shipfox-2vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-2vcpu
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "namespacelabs/nscloud-checkout-action@v7"
         with:
           fetch-depth: 0
       - name: Setup Nix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: shipfox-4vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-4vcpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
       - name: Setup Nix

--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -4,10 +4,10 @@ on:
     types: [published]
 jobs:
   push:
-    runs-on: shipfox-2vcpu-ubuntu-2404
+    runs-on: namespace-profile-linux-amd64-2vcpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
       - name: Setup Nix


### PR DESCRIPTION
## Summary

Migrate CI runners from Shipfox to Namespace.so as part of the org-wide CI infrastructure migration.

### Per-workflow changes
- `runs-on: shipfox-Xvcpu-ubuntu-2404` → `runs-on: namespace-profile-linux-amd64-Xvcpu`
- `actions/checkout@v6` → `namespacelabs/nscloud-checkout-action@v7` (git mirror caching, `filter: tree:0` → `dissociate: true`)
- `docker/setup-qemu-action` removed (Namespace builds AMD64+ARM64 natively without emulation)
- `docker/setup-buildx-action` → `namespacelabs/nscloud-setup-buildx-action@v0` (Remote Builders)

### Pattern A composite (`.github/actions/default/action.yml`)
- `nix-community/cache-nix-action@v7` → removed (incompatible with Namespace runner setup, see banking-bridge testing)
- `actions/cache@v5` → `namespacelabs/nscloud-cache-action@v1` (paths preserved)

### Validation
- Reference migration: formancehq/ledger#1336 (4 successful runs measured, GoReleaser validated with multi-arch native build)
- 4 banking-bridge PRs validated this exact patch flow

## Test plan
- [ ] CI passes on this PR
- [ ] No regression in build duration vs prior shipfox runs
- [ ] `GoReleaser` works (add `build-images` label if needed to trigger)