### PR TITLE
fix(core): make migration Job hooks stable across Helm + ArgoCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 | Readme | Chart Version | App Version | Description | Hub |
 |--------|---------------|-------------|-------------|-----|
-| [Agent](./charts/agent/README.md) | 2.14.0 | v2.10.0 | Formance Membership Agent Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/agent)](https://artifacthub.io/packages/search?repo=agent) |
-| [Cloudprem](./charts/cloudprem/README.md) | 4.9.2 | latest | Formance control-plane | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem) |
-| [Console-V3](./charts/console-v3/README.md) | 3.6.2 | v2.6.2 | Formance Console | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/console-v3)](https://artifacthub.io/packages/search?repo=console-v3) |
-| [Core](./charts/core/README.md) | 1.5.1 | latest | Formance Core Library | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/core)](https://artifacthub.io/packages/search?repo=core) |
-| [Formance](./charts/formance/README.md) | 1.13.4 | latest | Formance Platform - Unified Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance)](https://artifacthub.io/packages/search?repo=formance) |
-| [Membership](./charts/membership/README.md) | 3.5.0 | v2.5.0 | Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
-| [Portal](./charts/portal/README.md) | 3.6.2 | v2.6.2 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | 3.10.7 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
-| [Stargate](./charts/stargate/README.md) | 0.10.1 | latest | Formance EE Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
+| [Agent](./charts/agent/README.md) | 2.15.0 | v2.10.0 | Formance Membership Agent Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/agent)](https://artifacthub.io/packages/search?repo=agent) |
+| [Cloudprem](./charts/cloudprem/README.md) | 4.10.0 | latest | Formance control-plane | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem) |
+| [Console-V3](./charts/console-v3/README.md) | 3.7.0 | v2.6.2 | Formance Console | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/console-v3)](https://artifacthub.io/packages/search?repo=console-v3) |
+| [Core](./charts/core/README.md) | 1.6.0 | latest | Formance Core Library | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/core)](https://artifacthub.io/packages/search?repo=core) |
+| [Formance](./charts/formance/README.md) | 1.14.0 | latest | Formance Platform - Unified Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance)](https://artifacthub.io/packages/search?repo=formance) |
+| [Membership](./charts/membership/README.md) | 3.6.0 | v2.5.0 | Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
+| [Portal](./charts/portal/README.md) | 3.7.0 | v2.6.2 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
+| [Regions](./charts/regions/README.md) | 3.11.0 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Stargate](./charts/stargate/README.md) | 0.11.0 | latest | Formance EE Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute
 

--- a/charts/agent/Chart.lock
+++ b/charts/agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 1.5.1
-digest: sha256:29b6f82721cb8cb5ffc9fb8f4a15c0368bd43323551b1aec43c9d24f559ec24a
-generated: "2026-03-13T11:53:02.207688+01:00"
+  version: 1.6.0
+digest: sha256:6d15ce1c622425ece61bcf8f444d16ee5462059a286ef39b2cd78723e91b705f
+generated: "2026-06-22T09:26:38.333292+02:00"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 2.14.0
+version: 2.15.0
 
 appVersion: "v2.10.0"
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.10.0](https://img.shields.io/badge/AppVersion-v2.10.0-informational?style=flat-square)
+![Version: 2.15.0](https://img.shields.io/badge/Version-2.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.10.0](https://img.shields.io/badge/AppVersion-v2.10.0-informational?style=flat-square)
 
 Formance Membership Agent Helm Chart
 

--- a/charts/cloudprem/Chart.lock
+++ b/charts/cloudprem/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: membership
   repository: file://../membership
-  version: 3.5.0
+  version: 3.6.0
 - name: portal
   repository: file://../portal
-  version: 3.6.2
+  version: 3.7.0
 - name: console-v3
   repository: file://../console-v3
-  version: 3.6.2
-digest: sha256:44566bf3148e8cfc5b4e515caf5afcee42eb0f046b5d503ff16b3d70efa3eace
-generated: "2026-06-15T11:00:08.043908+02:00"
+  version: 3.7.0
+digest: sha256:daed3f4af5ace511de313180abe29e55726644ec51b9acd1a895b1e66ed41369
+generated: "2026-06-22T09:33:02.325748+02:00"

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.9.2
+version: 4.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,7 +1,7 @@
 # Formance cloudprem Helm chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem)
-![Version: 4.9.2](https://img.shields.io/badge/Version-4.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 4.10.0](https://img.shields.io/badge/Version-4.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance control-plane
 

--- a/charts/console-v3/Chart.lock
+++ b/charts/console-v3/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 1.5.1
+  version: 1.6.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.7.3
-digest: sha256:94f58a97ea12e8fade08b77e895cd51c19428d0c026001235cedde428c76eb03
-generated: "2026-06-09T14:59:37.072444+02:00"
+  version: 18.7.6
+digest: sha256:2de666ebc52f71210ae299061f7d473e5ab0480dab96d22deb0ad4c348519066
+generated: "2026-06-22T09:26:55.92648+02:00"

--- a/charts/console-v3/Chart.yaml
+++ b/charts/console-v3/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.6.2
+version: 3.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/console-v3/README.md
+++ b/charts/console-v3/README.md
@@ -1,6 +1,6 @@
 # console-v3
 
-![Version: 3.6.2](https://img.shields.io/badge/Version-3.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.6.2](https://img.shields.io/badge/AppVersion-v2.6.2-informational?style=flat-square)
+![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.6.2](https://img.shields.io/badge/AppVersion-v2.6.2-informational?style=flat-square)
 
 Formance Console
 

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,5 +15,5 @@ sources:
 - "https://github.com/formancehq/helm/tree/main/charts/core"
 
 type: library
-version: 1.5.1
+version: 1.6.0
 appVersion: "latest"

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # Formance core Library
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 Formance Core Library
 
 **Homepage:** <https://formance.com>

--- a/charts/core/templates/_job.tpl
+++ b/charts/core/templates/_job.tpl
@@ -1,13 +1,28 @@
 {{/**
-  
-    This way is only reliable when using helm install and helm upgrade.
-    ArgoCD use helm template
-  
+    Hook annotations for a migration Job — works under plain `helm
+    install/upgrade` AND ArgoCD (which auto-translates Helm hook
+    annotations to its native PreSync/BeforeHookCreation/sync-wave).
+
+    Gated by `.Values.feature.migrationHooks` so consumers can opt
+    out (e.g. when running migrations via a separate orchestrator).
+
+    - `pre-install,pre-upgrade` keeps the Job's identity stable as a
+      hook in BOTH install and upgrade. The previous
+      `pre-upgrade`-only-on-upgrade gate meant the resource was a plain
+      release object on install and flipped to a hook on the next
+      upgrade, which produced "Job already exists" errors and orphans
+      on uninstall.
+
+    - `before-hook-creation` deletes the previous Job before recreating
+      so image bumps and other spec changes don't hit Job-spec
+      immutability. `hook-succeeded` is intentionally NOT here so
+      operators can `kubectl logs` post-success; cleanup is bounded by
+      `ttlSecondsAfterFinished` on the Job spec.
   **/}}
 {{- define "core.job.annotations" -}}
-{{- if and (not .Release.IsInstall) .Values.feature.migrationHooks }}
-helm.sh/hook: pre-upgrade
-helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+{{- if .Values.feature.migrationHooks }}
+helm.sh/hook: pre-install,pre-upgrade
+helm.sh/hook-delete-policy: before-hook-creation
 helm.sh/hook-weight: "10"
 {{- end }}
 {{- end }}

--- a/charts/core/templates/_postgres.tpl
+++ b/charts/core/templates/_postgres.tpl
@@ -1,11 +1,23 @@
 
-{{- /**DEPRECATED **/}}
+{{- /**DEPRECATED — use `core.job.annotations` directly **/}}
 {{- define "core.postgres.job.annotations" -}}
 {{- include "core.job.annotations" . -}}
 {{- end }}
-{{- /**DEPRECATED **/}}
+
+{{/**
+    Hook annotations for the migration Job's ServiceAccount. Same
+    Helm hook semantics as `core.job.annotations` and gated by the
+    same `.Values.feature.migrationHooks` flag, but with a LOWER
+    `hook-weight` so the SA is created before the Job that references
+    it (otherwise the Job's pod fails to schedule with "ServiceAccount
+    not found"). ArgoCD auto-translates `hook-weight` to `sync-wave`.
+  **/}}
 {{- define "core.postgres.job.sa.annotations" -}}
-{{- include "core.job.annotations" . -}}
+{{- if .Values.feature.migrationHooks }}
+helm.sh/hook: pre-install,pre-upgrade
+helm.sh/hook-delete-policy: before-hook-creation
+helm.sh/hook-weight: "0"
+{{- end }}
 {{- end }}
 
 {{/** 

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.7.3
+  version: 18.7.6
 - name: regions
   repository: file://../regions
-  version: 3.10.7
+  version: 3.11.0
 - name: cloudprem
   repository: file://../cloudprem
-  version: 4.9.2
-digest: sha256:ab00bb5977dbfacbd126cff2c1745fbd0e6110d197f74e273586f805cb5c33f2
-generated: "2026-06-15T11:54:47.440585+02:00"
+  version: 4.10.0
+digest: sha256:e6e6353c32fc72665265ce60d619cb75a12a10de216257d8a5629abefb57d658
+generated: "2026-06-22T09:33:03.509948+02:00"

--- a/charts/formance/Chart.yaml
+++ b/charts/formance/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 1.13.4
+version: 1.14.0
 appVersion: "latest"
 # The "-0" suffix is required for GKE compatibility. GKE versions contain
 # build metadata like "v1.33.5-gke.2392000" which semver treats as pre-release.

--- a/charts/formance/README.md
+++ b/charts/formance/README.md
@@ -1,6 +1,6 @@
 # formance
 
-![Version: 1.13.4](https://img.shields.io/badge/Version-1.13.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Platform - Unified Helm Chart
 

--- a/charts/membership/Chart.lock
+++ b/charts/membership/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.7.3
+  version: 18.7.6
 - name: dex
   repository: https://charts.dexidp.io
   version: 0.24.1
 - name: core
   repository: file://../core
-  version: 1.5.1
-digest: sha256:f516e5a8711af3c7a57a609c043c3eb83aa8b5db56ccc4e8c449b66f09725253
-generated: "2026-06-09T14:59:33.302603+02:00"
+  version: 1.6.0
+digest: sha256:b130a654a9fd60d5f6da5bf73a0d9710e10060b2a54a163662392f1206835f9a
+generated: "2026-06-22T09:26:52.299904+02:00"

--- a/charts/membership/Chart.yaml
+++ b/charts/membership/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/membership/README.md
+++ b/charts/membership/README.md
@@ -1,6 +1,6 @@
 # Formance membership Helm chart
 
-![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.5.0](https://img.shields.io/badge/AppVersion-v2.5.0-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.5.0](https://img.shields.io/badge/AppVersion-v2.5.0-informational?style=flat-square)
 Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions.
 
 ## Requirements

--- a/charts/portal/Chart.lock
+++ b/charts/portal/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 1.5.1
+  version: 1.6.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.7.3
-digest: sha256:94f58a97ea12e8fade08b77e895cd51c19428d0c026001235cedde428c76eb03
-generated: "2026-06-09T14:59:22.340965+02:00"
+  version: 18.7.6
+digest: sha256:2de666ebc52f71210ae299061f7d473e5ab0480dab96d22deb0ad4c348519066
+generated: "2026-06-22T09:26:42.312172+02:00"

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.6.2
+version: 3.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -1,6 +1,6 @@
 # portal
 
-![Version: 3.6.2](https://img.shields.io/badge/Version-3.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.6.2](https://img.shields.io/badge/AppVersion-v2.6.2-informational?style=flat-square)
+![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.6.2](https://img.shields.io/badge/AppVersion-v2.6.2-informational?style=flat-square)
 
 Formance Portal
 

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: agent
   repository: file://../agent
-  version: 2.14.0
+  version: 2.15.0
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
   version: 3.11.2
 - name: core
   repository: file://../core
-  version: 1.5.1
-digest: sha256:866749c40f0605be3ee16788b1a99cacc325faf749bafa44da87479d1092e164
-generated: "2026-06-12T12:28:48.576894+02:00"
+  version: 1.6.0
+digest: sha256:ac7f9226c98c82d59e82c848beb4021e1d26e13b33772d22f721f04f79c9967d
+generated: "2026-06-22T09:32:46.086595+02:00"

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 3.10.7
+version: 3.11.0
 appVersion: "latest"
 
 dependencies:

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # Formance regions Helm chart
 
-![Version: 3.10.7](https://img.shields.io/badge/Version-3.10.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 3.11.0](https://img.shields.io/badge/Version-3.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 Formance Private Regions Helm Chart
 
 ## Requirements

--- a/charts/stargate/Chart.lock
+++ b/charts/stargate/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 1.5.1
+  version: 1.6.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.5.38
-digest: sha256:663ca8c28a6de42337fb1f7a30d6588113b6c7150f0a053edf0886641da186e8
-generated: "2026-03-13T11:53:12.310361+01:00"
+digest: sha256:3487d243930e76ecf46e3ad85dffa3367623fa55d4755b20975f88ffac17aa7a
+generated: "2026-06-22T09:26:46.18892+02:00"

--- a/charts/stargate/Chart.yaml
+++ b/charts/stargate/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/stargate/README.md
+++ b/charts/stargate/README.md
@@ -1,6 +1,6 @@
 # Formance stargate Helm chart
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 Formance EE Stargate gRPC Gateway
 
 ## Requirements


### PR DESCRIPTION
## Why we have this upgrade bug

The bug is **resource-identity flip caused by a conditional hook annotation**.

The old helper gated hooks on `and (not .Release.IsInstall) .Values.feature.migrationHooks`. Read that condition carefully:

- On `helm install` → `.Release.IsInstall` is true → condition is false → **no hook annotation**. The migration Job is emitted as a normal release resource and Helm tracks it in the release manifest.
- On the next `helm upgrade` (with `migrationHooks=true`) → `.Release.IsInstall` is false → condition is true → **`pre-upgrade` hook annotation is added**. Helm now treats the same Job as a hook.

The problem is that **Helm tracks hooks outside the release manifest**. A resource that was a release-managed Job on install becomes a hook-managed Job on upgrade, but with the same name in the same namespace. Helm sees two things claiming the same Kubernetes object:

1. The release manifest still references the old Job (as a release resource).
2. The hook lifecycle tries to create a new Job with the same name.

Result: `Job already exists` on the first upgrade. Worse, on a later `helm uninstall`, Helm only sees the new-identity hook record and not the old-identity release resource — the original Job is left orphaned in the cluster.

A second smaller bug compounded it: `hook-delete-policy` included `hook-succeeded`, so on a successful migration the pod was destroyed immediately. Operators investigating a downstream regression had no `kubectl logs` to look at.

A third related issue: ArgoCD's `helm template` rendering path also reads Helm hook annotations and translates them to its native `PreSync` / `BeforeHookCreation` / `sync-wave`. But because the old gate only emitted hooks on upgrade-with-flag, ArgoCD saw a plain Job resource on every sync and tripped Job-spec immutability on the second sync.

## The fix

- Gate simplified to `if .Values.feature.migrationHooks`. The flag is preserved (see below), but the condition no longer depends on `IsInstall`. When the flag is on, the Job carries hook annotations on **both** install and upgrade — identity is stable for the entire lifecycle.
- Hooks broadened from `pre-upgrade` only to `pre-install,pre-upgrade`.
- `hook-delete-policy` reduced to `before-hook-creation`. Cleanup is now bounded by the Job's `ttlSecondsAfterFinished`, which keeps the pod around for `kubectl logs` post-success.
- ArgoCD annotations are intentionally NOT emitted — ArgoCD auto-translates the Helm hook annotations.

A new `core.postgres.job.sa.annotations` helper (also gated by `feature.migrationHooks`) emits hook annotations on the migration ServiceAccount with `hook-weight: "0"` so the SA materializes before the Job (`hook-weight: "10"`). Without this, consumers using a dedicated migration SA hit `ServiceAccount not found` at Job pod scheduling time.

## Is it still backwards-compatible with external systems?

**Yes, for every relevant external surface.**

- **Plain `helm install` / `helm upgrade` consumers with `feature.migrationHooks=false` (the default)**: zero behaviour change. The helper emits no annotations, the Job is a plain release resource, exactly as before.
- **Plain `helm install` / `helm upgrade` consumers with `feature.migrationHooks=true`**: previously broken on first upgrade. Now works — Job is a stable hook identity throughout.
- **ArgoCD consumers**: no values change. With `feature.migrationHooks=true`, ArgoCD's Helm-template renderer translates the new `pre-install,pre-upgrade` annotations to `PreSync`, and `before-hook-creation` to `BeforeHookCreation`. Migration runs cleanly as `PreSync` and replaces the previous Job on each sync (covers image bumps without hitting Job immutability).
- **Consumers using the legacy alias `core.postgres.job.annotations`**: still works. The alias is kept (deprecated) and delegates to `core.job.annotations`.
- **Consumers using a dedicated migration SA** via `core.postgres.job.serviceAccountName` + `core.postgres.job.sa.annotations`: new helper plugs in cleanly with `hook-weight: "0"` ordering. Existing SA paths without this helper continue to work as before.

The PR also cascades the `core` minor bump through every dependent chart (`agent`, `console-v3`, `membership`, `portal`, `regions`, `stargate`, `cloudprem`, `formance`) per the `CLAUDE.md` cascade rule, so umbrella consumers pick the new core version up automatically.

## Is there a feature gate?

**Yes — `feature.migrationHooks` is preserved and is the single gate.**

- Defined per consumer chart in `values.yaml` as `feature.migrationHooks: false` by default (portal, console-v3, membership).
- When `false`: helper emits no annotations, Job is a plain release resource, no hook lifecycle. Identical to the old default behaviour.
- When `true`: helper emits the full Helm hook annotations on both install and upgrade. Stable identity throughout the Job's lifecycle.
- The flag also gates `core.postgres.job.sa.annotations` so the SA and Job toggle together — there's no half-on state where the Job is a hook but the SA isn't (or vice versa).
- Consumers can flip the flag without coordinating a chart-version change; flipping `false → true` on a release that already has a plain Job will recreate the Job as a hook on the next upgrade (the `Job already exists` error surface is removed because the new code emits `pre-install,pre-upgrade` consistently).

## Cascade

`core` bumps `1.5.1 → 1.6.0` (minor: helper semantics change, no breaking API). Every dependent chart bumped to mirror the minor step:

| Chart | Old | New |
|---|---|---|
| core | 1.5.1 | 1.6.0 |
| agent | 2.14.0 | 2.15.0 |
| console-v3 | 3.6.2 | 3.7.0 |
| membership | 3.5.0 | 3.6.0 |
| portal | 3.6.2 | 3.7.0 |
| regions | 3.10.7 | 3.11.0 |
| stargate | 0.10.1 | 0.11.0 |
| cloudprem | 4.9.2 | 4.10.0 |
| formance | 1.13.4 | 1.14.0 |

## Test plan

- [x] `just pc` passes (helm lint, render, helm-docs, README regen, schema regen)
- [ ] `helm install` + `helm upgrade` cycle with `feature.migrationHooks=true`: Job is a hook on both, identity stable, no orphans on uninstall
- [ ] `helm install` + `helm upgrade` with `feature.migrationHooks=false` (default): Job is a plain resource — no behaviour change vs current main
- [ ] ArgoCD sync with `feature.migrationHooks=true`: Job runs as `PreSync`, recreated each sync via `BeforeHookCreation`
- [ ] Failed migration: pod stays around for `kubectl logs`
- [ ] Successful migration: Job cleaned up by `ttlSecondsAfterFinished`, not by hook policy
- [ ] Dedicated migration SA path (consumer sets `core.postgres.job.serviceAccountName` + `core.postgres.job.sa.annotations`): SA materializes before the Job, no `ServiceAccount not found` scheduling failures