### PR TITLE
chore(regions): upgrade webhooks to v2.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | [Formance](./charts/formance/README.md) | 1.10.0 | latest | Formance Platform - Unified Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance)](https://artifacthub.io/packages/search?repo=formance) |
 | [Membership](./charts/membership/README.md) | 3.3.0 | v2.3.1 | Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | 3.5.0 | v2.5.0 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | 3.9.6 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | 3.9.7 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.10.1 | latest | Formance EE Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 18.6.7
 - name: regions
   repository: file://../regions
-  version: 3.9.6
+  version: 3.9.7
 - name: cloudprem
   repository: file://../cloudprem
   version: 4.6.2
-digest: sha256:bc0b926dc625ae38113c898c5fed9fcfc6f17c8b45fc79ff61e382b8b7248d7f
-generated: "2026-05-21T15:01:29.54405+02:00"
+digest: sha256:96e366795bf5a8a3d6a0d9a4be3181ba2ff4b28c47d97bdd55f3902706f38a69
+generated: "2026-05-21T09:55:04.840361-04:00"

--- a/charts/formance/README.md
+++ b/charts/formance/README.md
@@ -547,7 +547,7 @@ Kubernetes: `>=1.14.0-0`
 | regions.versions.files."v2.1".search | string | `"v2.0.24"` |  |
 | regions.versions.files."v2.1".stargate | string | `"v2.2.2"` |  |
 | regions.versions.files."v2.1".wallets | string | `"v2.1.5"` |  |
-| regions.versions.files."v2.1".webhooks | string | `"v2.3.1"` |  |
+| regions.versions.files."v2.1".webhooks | string | `"v2.3.2"` |  |
 | regions.versions.files."v2.2".auth | string | `"v2.4.1"` |  |
 | regions.versions.files."v2.2".gateway | string | `"v2.2.0"` |  |
 | regions.versions.files."v2.2".ledger | string | `"v2.2.58"` |  |
@@ -557,7 +557,7 @@ Kubernetes: `>=1.14.0-0`
 | regions.versions.files."v2.2".search | string | `"v2.0.24"` |  |
 | regions.versions.files."v2.2".stargate | string | `"v2.2.2"` |  |
 | regions.versions.files."v2.2".wallets | string | `"v2.1.5"` |  |
-| regions.versions.files."v2.2".webhooks | string | `"v2.3.1"` |  |
+| regions.versions.files."v2.2".webhooks | string | `"v2.3.2"` |  |
 | regions.versions.files."v3.0".auth | string | `"v2.4.1"` |  |
 | regions.versions.files."v3.0".gateway | string | `"v2.2.0"` |  |
 | regions.versions.files."v3.0".ledger | string | `"v2.2.58"` |  |
@@ -567,7 +567,7 @@ Kubernetes: `>=1.14.0-0`
 | regions.versions.files."v3.0".search | string | `"v2.1.0"` |  |
 | regions.versions.files."v3.0".stargate | string | `"v2.2.2"` |  |
 | regions.versions.files."v3.0".wallets | string | `"v2.1.5"` |  |
-| regions.versions.files."v3.0".webhooks | string | `"v2.3.1"` |  |
+| regions.versions.files."v3.0".webhooks | string | `"v2.3.2"` |  |
 | regions.versions.files."v3.1".auth | string | `"v2.4.1"` |  |
 | regions.versions.files."v3.1".gateway | string | `"v2.2.0"` |  |
 | regions.versions.files."v3.1".ledger | string | `"v2.3.19"` |  |
@@ -577,7 +577,7 @@ Kubernetes: `>=1.14.0-0`
 | regions.versions.files."v3.1".search | string | `"v2.1.0"` |  |
 | regions.versions.files."v3.1".stargate | string | `"v2.2.2"` |  |
 | regions.versions.files."v3.1".wallets | string | `"v2.1.5"` |  |
-| regions.versions.files."v3.1".webhooks | string | `"v2.3.1"` |  |
+| regions.versions.files."v3.1".webhooks | string | `"v2.3.2"` |  |
 | regions.versions.files."v3.2".auth | string | `"v2.4.3"` |  |
 | regions.versions.files."v3.2".gateway | string | `"v2.2.0"` |  |
 | regions.versions.files."v3.2".ledger | string | `"v2.4.5"` |  |
@@ -588,7 +588,7 @@ Kubernetes: `>=1.14.0-0`
 | regions.versions.files."v3.2".stargate | string | `"v2.2.2"` |  |
 | regions.versions.files."v3.2".transactionplane | string | `"v0.2.1"` |  |
 | regions.versions.files."v3.2".wallets | string | `"v2.1.5"` |  |
-| regions.versions.files."v3.2".webhooks | string | `"v2.3.1"` |  |
+| regions.versions.files."v3.2".webhooks | string | `"v2.3.2"` |  |
 | regions.versions.files.default.auth | string | `"v0.4.4"` |  |
 | regions.versions.files.default.gateway | string | `"v2.0.18"` |  |
 | regions.versions.files.default.ledger | string | `"v1.10.14"` |  |

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 3.9.6
+version: 3.9.7
 appVersion: "latest"
 
 dependencies:

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # Formance regions Helm chart
 
-![Version: 3.9.6](https://img.shields.io/badge/Version-3.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 3.9.7](https://img.shields.io/badge/Version-3.9.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 Formance Private Regions Helm Chart
 
 ## Requirements
@@ -113,7 +113,7 @@ Then configure it through the `global.licence.token` and `global.licence.cluster
 | versions.files."v2.1".search | string | `"v2.0.24"` |  |
 | versions.files."v2.1".stargate | string | `"v2.2.2"` |  |
 | versions.files."v2.1".wallets | string | `"v2.1.5"` |  |
-| versions.files."v2.1".webhooks | string | `"v2.3.1"` |  |
+| versions.files."v2.1".webhooks | string | `"v2.3.2"` |  |
 | versions.files."v2.2".auth | string | `"v2.4.1"` |  |
 | versions.files."v2.2".gateway | string | `"v2.2.0"` |  |
 | versions.files."v2.2".ledger | string | `"v2.2.58"` |  |
@@ -123,7 +123,7 @@ Then configure it through the `global.licence.token` and `global.licence.cluster
 | versions.files."v2.2".search | string | `"v2.0.24"` |  |
 | versions.files."v2.2".stargate | string | `"v2.2.2"` |  |
 | versions.files."v2.2".wallets | string | `"v2.1.5"` |  |
-| versions.files."v2.2".webhooks | string | `"v2.3.1"` |  |
+| versions.files."v2.2".webhooks | string | `"v2.3.2"` |  |
 | versions.files."v3.0".auth | string | `"v2.4.1"` |  |
 | versions.files."v3.0".gateway | string | `"v2.2.0"` |  |
 | versions.files."v3.0".ledger | string | `"v2.2.58"` |  |
@@ -133,7 +133,7 @@ Then configure it through the `global.licence.token` and `global.licence.cluster
 | versions.files."v3.0".search | string | `"v2.1.0"` |  |
 | versions.files."v3.0".stargate | string | `"v2.2.2"` |  |
 | versions.files."v3.0".wallets | string | `"v2.1.5"` |  |
-| versions.files."v3.0".webhooks | string | `"v2.3.1"` |  |
+| versions.files."v3.0".webhooks | string | `"v2.3.2"` |  |
 | versions.files."v3.1".auth | string | `"v2.4.1"` |  |
 | versions.files."v3.1".gateway | string | `"v2.2.0"` |  |
 | versions.files."v3.1".ledger | string | `"v2.3.19"` |  |
@@ -143,7 +143,7 @@ Then configure it through the `global.licence.token` and `global.licence.cluster
 | versions.files."v3.1".search | string | `"v2.1.0"` |  |
 | versions.files."v3.1".stargate | string | `"v2.2.2"` |  |
 | versions.files."v3.1".wallets | string | `"v2.1.5"` |  |
-| versions.files."v3.1".webhooks | string | `"v2.3.1"` |  |
+| versions.files."v3.1".webhooks | string | `"v2.3.2"` |  |
 | versions.files."v3.2".auth | string | `"v2.4.3"` |  |
 | versions.files."v3.2".gateway | string | `"v2.2.0"` |  |
 | versions.files."v3.2".ledger | string | `"v2.4.5"` |  |
@@ -154,7 +154,7 @@ Then configure it through the `global.licence.token` and `global.licence.cluster
 | versions.files."v3.2".stargate | string | `"v2.2.2"` |  |
 | versions.files."v3.2".transactionplane | string | `"v0.2.1"` |  |
 | versions.files."v3.2".wallets | string | `"v2.1.5"` |  |
-| versions.files."v3.2".webhooks | string | `"v2.3.1"` |  |
+| versions.files."v3.2".webhooks | string | `"v2.3.2"` |  |
 | versions.files.default.auth | string | `"v0.4.4"` |  |
 | versions.files.default.gateway | string | `"v2.0.18"` |  |
 | versions.files.default.ledger | string | `"v1.10.14"` |  |

--- a/charts/regions/values.yaml
+++ b/charts/regions/values.yaml
@@ -105,7 +105,7 @@ versions:
       stargate: v2.2.2
       auth: v2.4.1
       wallets: v2.1.5
-      webhooks: v2.3.1
+      webhooks: v2.3.2
       gateway: v2.2.0
       payments: v2.0.32
       orchestration: v2.0.24
@@ -116,7 +116,7 @@ versions:
       stargate: v2.2.2
       auth: v2.4.1
       wallets: v2.1.5
-      webhooks: v2.3.1
+      webhooks: v2.3.2
       gateway: v2.2.0
       payments: v2.0.32
       orchestration: v2.0.24
@@ -128,7 +128,7 @@ versions:
       stargate: v2.2.2
       auth: v2.4.1
       wallets: v2.1.5
-      webhooks: v2.3.1
+      webhooks: v2.3.2
       gateway: v2.2.0
       orchestration: v2.1.1
       reconciliation: v2.1.0
@@ -139,7 +139,7 @@ versions:
       stargate: v2.2.2
       auth: v2.4.1
       wallets: v2.1.5
-      webhooks: v2.3.1
+      webhooks: v2.3.2
       gateway: v2.2.0
       orchestration: v2.4.1
       reconciliation: v2.2.0
@@ -150,7 +150,7 @@ versions:
       stargate: v2.2.2
       auth: v2.4.3
       wallets: v2.1.5
-      webhooks: v2.3.1
+      webhooks: v2.3.2
       gateway: v2.2.0
       orchestration: v2.6.0
       reconciliation: v2.2.2


### PR DESCRIPTION
## Summary
- bump regions chart version to 3.9.7
- upgrade embedded webhooks versions from v2.3.1 to v2.3.2 for v2.1 through v3.2 stacks
- regenerate Helm docs and formance chart lock

## Validation
- just pc