### PR TITLE
chore(regions): upgrade v3.2 versions

### DIFF
--- a/charts/formance/README.md
+++ b/charts/formance/README.md
@@ -586,7 +586,7 @@ Kubernetes: `>=1.14.0-0`
 | regions.versions.files."v3.2".reconciliation | string | `"v2.2.2"` |  |
 | regions.versions.files."v3.2".search | string | `"v2.1.0"` |  |
 | regions.versions.files."v3.2".stargate | string | `"v2.2.2"` |  |
-| regions.versions.files."v3.2".transactionplane | string | `"v0.2.1"` |  |
+| regions.versions.files."v3.2".transactionplane | string | `"v0.9.0"` |  |
 | regions.versions.files."v3.2".wallets | string | `"v2.1.5"` |  |
 | regions.versions.files."v3.2".webhooks | string | `"v2.3.2"` |  |
 | regions.versions.files.default.auth | string | `"v0.4.4"` |  |

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -152,7 +152,7 @@ Then configure it through the `global.licence.token` and `global.licence.cluster
 | versions.files."v3.2".reconciliation | string | `"v2.2.2"` |  |
 | versions.files."v3.2".search | string | `"v2.1.0"` |  |
 | versions.files."v3.2".stargate | string | `"v2.2.2"` |  |
-| versions.files."v3.2".transactionplane | string | `"v0.2.1"` |  |
+| versions.files."v3.2".transactionplane | string | `"v0.9.0"` |  |
 | versions.files."v3.2".wallets | string | `"v2.1.5"` |  |
 | versions.files."v3.2".webhooks | string | `"v2.3.2"` |  |
 | versions.files.default.auth | string | `"v0.4.4"` |  |

--- a/charts/regions/values.yaml
+++ b/charts/regions/values.yaml
@@ -152,7 +152,7 @@ versions:
       reconciliation: v2.2.2
       search: v2.1.0
       stargate: v2.2.2
-      transactionplane: v0.2.1
+      transactionplane: v0.9.0
       wallets: v2.1.5
       webhooks: v2.3.2
 


### PR DESCRIPTION
## Summary
- upgrade the regions v3.2 transactionplane version to v0.9.0
- refresh generated Helm README entries for regions and formance

## Validation
- just pc