### PR TITLE
chore(regions): upgrade operator to 3.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | [Formance](./charts/formance/README.md) | 1.10.1 | latest | Formance Platform - Unified Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance)](https://artifacthub.io/packages/search?repo=formance) |
 | [Membership](./charts/membership/README.md) | 3.3.0 | v2.3.1 | Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | 3.5.1 | v2.5.1 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | 3.9.8 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | 3.9.9 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.10.1 | latest | Formance EE Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 18.6.7
 - name: regions
   repository: file://../regions
-  version: 3.9.8
+  version: 3.9.9
 - name: cloudprem
   repository: file://../cloudprem
   version: 4.6.2
-digest: sha256:cb1d629d9bf2034ba50eefb8814795d12a0dc518ad6cf6ccf74d2ddcc3ee7427
-generated: "2026-05-22T16:42:16.78034+02:00"
+digest: sha256:2c19e3ab77f3578bee3f66f018e2b4875c4a410252c6de1c3e3e952375fc3c23
+generated: "2026-05-26T09:23:48.252229+02:00"

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.1
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
-  version: 3.9.6
+  version: 3.11.0
 - name: core
   repository: file://../core
   version: 1.5.1
-digest: sha256:9880c0e80388c5ae205b7588c1bdb28cf4bd4cc1663aa2a6f7a364629119e6ce
-generated: "2026-05-22T16:41:43.373138+02:00"
+digest: sha256:6ced20cea5e2be2c8b5f45872735c043059209964b919999152024485e072fdb
+generated: "2026-05-26T09:23:28.818101+02:00"

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 3.9.8
+version: 3.9.9
 appVersion: "latest"
 
 dependencies:

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # Formance regions Helm chart
 
-![Version: 3.9.8](https://img.shields.io/badge/Version-3.9.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 3.9.9](https://img.shields.io/badge/Version-3.9.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 Formance Private Regions Helm Chart
 
 ## Requirements

--- a/flake.lock
+++ b/flake.lock
@@ -23,12 +23,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
-        "revCount": 770807,
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "revCount": 1004030,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.770807%2Brev-a84ebe20c6bc2ecbcfb000a50776219f48d134cc/0195b626-8c1d-7fb9-9282-563af3d37ab9/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1004030%2Brev-64c08a7ca051951c8eae34e3e3cb1e202fe36786/019e5fd8-b716-7e01-9710-e44ec43dc50b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
 
   outputs = { self, nixpkgs, nur }:
     let
-      goVersion = 23;
+      goVersion = 25;
 
       supportedSystems = [
         "x86_64-linux"


### PR DESCRIPTION
## Summary
- upgrade the regions chart lock from operator 3.9.6 to 3.11.0
- bump regions chart version to 3.9.9
- regenerate chart docs and formance lock for the updated local regions chart

## CRDs
- verified the pulled operator 3.11.0 package embeds operator-crds 3.11.0

## Validation
- `just pc`
