### PR TITLE
chore: update membership and agent versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 | Readme | Chart Version | App Version | Description | Hub |
 |--------|---------------|-------------|-------------|-----|
-| [Agent](./charts/agent/README.md) | 2.13.1 | v2.9.0 | Formance Membership Agent Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/agent)](https://artifacthub.io/packages/search?repo=agent) |
-| [Cloudprem](./charts/cloudprem/README.md) | 4.6.2 | latest | Formance control-plane | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem) |
+| [Agent](./charts/agent/README.md) | 2.14.0 | v2.10.0 | Formance Membership Agent Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/agent)](https://artifacthub.io/packages/search?repo=agent) |
+| [Cloudprem](./charts/cloudprem/README.md) | 4.7.0 | latest | Formance control-plane | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem) |
 | [Console-V3](./charts/console-v3/README.md) | 3.5.1 | v2.5.1 | Formance Console | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/console-v3)](https://artifacthub.io/packages/search?repo=console-v3) |
 | [Core](./charts/core/README.md) | 1.5.1 | latest | Formance Core Library | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/core)](https://artifacthub.io/packages/search?repo=core) |
-| [Formance](./charts/formance/README.md) | 1.10.1 | latest | Formance Platform - Unified Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance)](https://artifacthub.io/packages/search?repo=formance) |
-| [Membership](./charts/membership/README.md) | 3.3.0 | v2.3.1 | Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
+| [Formance](./charts/formance/README.md) | 1.11.0 | latest | Formance Platform - Unified Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/formance)](https://artifacthub.io/packages/search?repo=formance) |
+| [Membership](./charts/membership/README.md) | 3.4.0 | v2.4.0 | Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions. | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/membership)](https://artifacthub.io/packages/search?repo=membership) |
 | [Portal](./charts/portal/README.md) | 3.5.1 | v2.5.1 | Formance Portal | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/portal)](https://artifacthub.io/packages/search?repo=portal) |
-| [Regions](./charts/regions/README.md) | 3.9.9 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
+| [Regions](./charts/regions/README.md) | 3.10.0 | latest | Formance Private Regions Helm Chart | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/regions)](https://artifacthub.io/packages/search?repo=regions) |
 | [Stargate](./charts/stargate/README.md) | 0.10.1 | latest | Formance EE Stargate gRPC Gateway | [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stargate)](https://artifacthub.io/packages/search?repo=stargate) |
 
 ## How to contribute

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -12,9 +12,9 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 2.13.1
+version: 2.14.0
 
-appVersion: "v2.9.0"
+appVersion: "v2.10.0"
 
 dependencies:
 - name: core

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.0](https://img.shields.io/badge/AppVersion-v2.9.0-informational?style=flat-square)
+![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.10.0](https://img.shields.io/badge/AppVersion-v2.10.0-informational?style=flat-square)
 
 Formance Membership Agent Helm Chart
 

--- a/charts/cloudprem/Chart.lock
+++ b/charts/cloudprem/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: membership
   repository: file://../membership
-  version: 3.3.0
+  version: 3.4.0
 - name: portal
   repository: file://../portal
   version: 3.5.1
 - name: console-v3
   repository: file://../console-v3
   version: 3.5.1
-digest: sha256:f8005d42e8ef6e899f763f3665e9e824bc98d8b81fcb0d9b66cbecc900db645a
-generated: "2026-05-25T12:07:45.651364+02:00"
+digest: sha256:473cb427ca5587ec28b31e86c7eff8df1fcae43a3df0864b6d90fa166e61b129
+generated: "2026-05-26T12:31:26.029122+02:00"

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.6.2
+version: 4.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,7 +1,7 @@
 # Formance cloudprem Helm chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudprem)](https://artifacthub.io/packages/search?repo=cloudprem)
-![Version: 4.6.2](https://img.shields.io/badge/Version-4.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 4.7.0](https://img.shields.io/badge/Version-4.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance control-plane
 

--- a/charts/formance/Chart.lock
+++ b/charts/formance/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 18.6.7
 - name: regions
   repository: file://../regions
-  version: 3.9.9
+  version: 3.10.0
 - name: cloudprem
   repository: file://../cloudprem
-  version: 4.6.2
-digest: sha256:2c19e3ab77f3578bee3f66f018e2b4875c4a410252c6de1c3e3e952375fc3c23
-generated: "2026-05-26T09:23:48.252229+02:00"
+  version: 4.7.0
+digest: sha256:7eb3ba94ebf4784516da94eb10c52fdf05afd7ae8539f3b3b89ab93e56bfc620
+generated: "2026-05-26T12:32:28.014523+02:00"

--- a/charts/formance/Chart.yaml
+++ b/charts/formance/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 1.10.1
+version: 1.11.0
 appVersion: "latest"
 # The "-0" suffix is required for GKE compatibility. GKE versions contain
 # build metadata like "v1.33.5-gke.2392000" which semver treats as pre-release.

--- a/charts/formance/README.md
+++ b/charts/formance/README.md
@@ -1,6 +1,6 @@
 # formance
 
-![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Formance Platform - Unified Helm Chart
 

--- a/charts/membership/Chart.yaml
+++ b/charts/membership/Chart.yaml
@@ -22,13 +22,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.3.1"
+appVersion: "v2.4.0"
 # The "-0" suffix is required for GKE compatibility. GKE versions contain
 # build metadata like "v1.33.5-gke.2392000" which semver treats as pre-release.
 # Without "-0", Helm rejects these versions as incompatible.

--- a/charts/membership/README.md
+++ b/charts/membership/README.md
@@ -1,6 +1,6 @@
 # Formance membership Helm chart
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.1](https://img.shields.io/badge/AppVersion-v2.3.1-informational?style=flat-square)
+![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
 Formance EE Membership API. Manage stacks, organizations, regions, invitations, users, roles, and permissions.
 
 ## Requirements

--- a/charts/regions/Chart.lock
+++ b/charts/regions/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: agent
   repository: file://../agent
-  version: 2.13.1
+  version: 2.14.0
 - name: operator
   repository: oci://ghcr.io/formancehq/helm
   version: 3.11.0
 - name: core
   repository: file://../core
   version: 1.5.1
-digest: sha256:6ced20cea5e2be2c8b5f45872735c043059209964b919999152024485e072fdb
-generated: "2026-05-26T09:23:28.818101+02:00"
+digest: sha256:f7d4616faa6c5ab4f72f8ebec40f12d5d868d363260b0a2b71c653f1428bf044
+generated: "2026-05-26T12:31:06.337598+02:00"

--- a/charts/regions/Chart.yaml
+++ b/charts/regions/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 icon: "https://avatars.githubusercontent.com/u/84325077?s=200&v=4"
 
 type: application
-version: 3.9.9
+version: 3.10.0
 appVersion: "latest"
 
 dependencies:

--- a/charts/regions/README.md
+++ b/charts/regions/README.md
@@ -1,6 +1,6 @@
 # Formance regions Helm chart
 
-![Version: 3.9.9](https://img.shields.io/badge/Version-3.9.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 3.10.0](https://img.shields.io/badge/Version-3.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 Formance Private Regions Helm Chart
 
 ## Requirements


### PR DESCRIPTION
## Summary
- update agent chart to 2.14.0 and appVersion to v2.10.0
- update membership chart to 3.4.0 and appVersion to v2.4.0
- bump regions, cloudprem, and formance chart versions for the updated default image tags
- regenerate chart README files and parent Chart.lock files

## Validation
- just pre-commit